### PR TITLE
feat(model): add Mentor model with basic fields and skills

### DIFF
--- a/backend/model/mentor.py
+++ b/backend/model/mentor.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+from typing import List
+from .skill import Skill
+
+class Mentor(BaseModel):
+    id: int
+    username: str
+    email: str
+    full_name: str
+    bio: str
+    skills: List[Skill]


### PR DESCRIPTION
Create Mentor model for mentors including id, username, email, full name, bio, and a list of associated skills.

The model uses Pydantic's BaseModel for data validation and serialization, and it references the existing Skill model for the skills list. This structure will allow you to:

1. Create mentor profiles with their basic information
2. Associate multiple skills with each mentor
3. Validate the data structure when saving to or retrieving from the database